### PR TITLE
Don't install the AWS SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt install -y ruby ruby-bundler ruby-dev git build-essential
 RUN gem install fustigit
 RUN gem install git
 RUN gem install docopt
-RUN git clone https://github.com/puppetlabs/vanagon.git && cd vanagon && bundle install && gem build -o vanagon.gem vanagon.gemspec && gem install --local ./vanagon.gem
+RUN git clone https://github.com/puppetlabs/vanagon.git && cd vanagon && bundle config without --local ec2-engine && bundle install && gem build -o vanagon.gem vanagon.gemspec && gem install --local ./vanagon.gem
 # move over the executables
 ADD https://github.com/puppetlabs/security-snyk-vanagon-action/releases/latest/download/vanagon_action /usr/local/bin/vanagon_action
 # ADD vanagon_action /usr/local/bin/vanagon_action


### PR DESCRIPTION
Vanagon's EC2 engine relies on the aws ruby sdk, which installs over 300 gems
and 150MB that we don't need to run the scan.