### PR TITLE
Add args for repository name and target reference in Snyk console

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,13 @@ RUN apt update
 RUN apt upgrade -y
 # install dependencies
 RUN apt install -y ruby ruby-bundler git
-RUN gem install fustigit
-RUN gem install git
-RUN gem install rchardet
-RUN gem install docopt
-RUN gem install lock_manager
-RUN gem install packaging
 RUN gem install vanagon
 # move over the executables
 ADD https://github.com/puppetlabs/security-snyk-vanagon-action/releases/latest/download/vanagon_action /usr/local/bin/vanagon_action
 # ADD vanagon_action /usr/local/bin/vanagon_action
 RUN chmod +x /usr/local/bin/vanagon_action
 # install snyk
-ADD https://github.com/snyk/snyk/releases/download/v1.720.0/snyk-linux /usr/local/bin/snyk 
+ADD https://github.com/snyk/cli/releases/download/v1.908.0/snyk-linux /usr/local/bin/snyk 
 RUN chmod 751 /usr/local/bin/snyk
 # startup script and startup
 ADD docker_confs/start_script.sh /usr/local/bin/start_script.sh

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-LOCAL_DIR = "/Users/oak.latt/dev"
+LOCAL_DIR = /Users/oak.latt/dev
 
 containerName = sec-van-action
-testFolder = $(LOCAL_DIR)/bolt-vanagon/
+testFolder = $(LOCAL_DIR)/pe-bolt-vanagon/
 # testFolder = $(LOCAL_DIR)/puppet-runtime/
 # testFolder = $(LOCAL_DIR)/pe-installer-vanagon/
 # testFolder = $(LOCAL_DIR)/pxp-agent-vanagon/
@@ -24,13 +24,14 @@ itest:
 	make build
 	make copy_testfiles
 	docker run --platform linux/amd64 -i --name $(containerName) \
-		-e INPUT_SNYKORG=sectest \
+		-e INPUT_SNYKORG=snyk-code-test-n8h \
 		-e INPUT_SNYKTOKEN=$(SNYK_TOKEN) \
 		-e GITHUB_WORKSPACE=/github/workspace \
+		-e GITHUB_REPOSITORY=olatt/snyk-test \
 		-e INPUT_SSHKEY="$(SSHKEY)" \
 		-e INPUT_SSHKEYNAME=id_ed25519 \
 		-e INPUT_SVDEBUG=true \
-		-e INPUT_BRANCH=main-test \
+		-e INPUT_BRANCH=test \
 		-v "$(LOCAL_DIR)/security-snyk-vanagon-action/testfiles/repo":"/github/workspace" \
 		-t $(containerName) 
 

--- a/main.go
+++ b/main.go
@@ -208,17 +208,20 @@ func snykTest(path, project, platform, org, branch string, noMonitor bool) ([]Vu
 	cwd, _ := os.Getwd()
 	fileArg := fmt.Sprintf("--file=%s/%s", cwd, gPath)
 	log.Println("testing ", project, platform)
+	getRepo := os.Getenv("GITHUB_REPOSITORY")
+	snykRepo := fmt.Sprintf("--remote-repo-url=https://github.com/%s.git", getRepo)
 	// run snyk monitor
 	if !noMonitor {
 		snykOrg := fmt.Sprintf("--org=%s", org)
-		var snykProj string
+		snykProj := fmt.Sprintf("--project-name=%s", platform)
+		var snykTref string
 		if branch == "" {
-			snykProj = fmt.Sprintf("--project-name=%s_%s", project, platform)
+			snykTref = fmt.Sprintf("--target-reference=%s", project)
 		} else {
-			snykProj = fmt.Sprintf("--project-name=%s_%s_%s", branch, project, platform)
+			snykTref = fmt.Sprintf("--target-reference=%s_%s", branch, project)
 		}
-		log.Printf("running: snyk monitor %s %s %s", snykOrg, snykProj, fileArg)
-		err := exec.Command("snyk", "monitor", snykOrg, snykProj, fileArg).Run()
+		log.Printf("running: snyk monitor %s %s %s %s %s", snykTref, snykRepo, snykOrg, snykProj, fileArg)
+		err := exec.Command("snyk", "monitor", snykTref, snykRepo, snykOrg, snykProj, fileArg).Run()
 		if err != nil {
 			log.Println("error running snyk monitor!", err)
 			return nil, err
@@ -271,7 +274,7 @@ func setDebugEnvVars() {
 	}
 	_ = out
 	// MAX_V_DEPS = 1
-	os.Setenv("INPUT_SNYKORG", "sectest")
+	os.Setenv("INPUT_SNYKORG", "snyk-code-test-n8h")
 	os.Setenv("INPUT_SNYKTOKEN", os.Getenv("SNYK_TOKEN"))
 	os.Setenv("GITHUB_WORKSPACE", "./testfiles/repo")
 	os.Setenv("INPUT_SVDEBUG", "true")

--- a/main_test.go
+++ b/main_test.go
@@ -74,22 +74,6 @@ func TestGetEnvVar(t *testing.T) {
 			t.Errorf("SkipProjects did not have val: %s", v)
 		}
 	}
-	expected_urls := map[string]string{
-		"artifactory.delivery.puppetlabs.net": "%s/xart",
-		"builds.delivery.puppetlabs.net":      "%s/xbuild",
-	}
-	for k, v := range expected_urls {
-		if val, ok := conf.UrlsToReplace[k]; ok {
-			if val != v {
-				t.Errorf("UrlsToReplace val doesn't match: Got: %s:%s", k, val)
-			}
-		} else {
-			t.Errorf("Couldn't find key %s in UrlsToReplace", k)
-		}
-	}
-	if conf.ProxyHost != "localhost" {
-		t.Errorf("proxyhost value wrong. Got: %s", conf.ProxyHost)
-	}
 	if !conf.Debug {
 		t.Errorf("Debug should have been true")
 	}

--- a/structs.go
+++ b/structs.go
@@ -24,8 +24,6 @@ type config struct {
 	SkipProjects    []string
 	SkipPlatforms   []string
 	GithubWorkspace string
-	UrlsToReplace   map[string]string
-	ProxyHost       string
 	NoMonitor       bool
 	Debug           bool
 	Branch          string


### PR DESCRIPTION
Fixes snyk monitor issue mismatching `group-name` and `project-name`.
The projects will now be organized as:
```
<repo-name>:
  <branch_project>:
    <platform>
```