### PR TITLE
Install libyaml-dev during container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:focal
 RUN apt update
 RUN apt upgrade -y
 # install dependencies
-RUN apt install -y ruby ruby-bundler ruby-dev git
+RUN apt install -y ruby ruby-bundler ruby-dev git libyaml-dev
 RUN gem install vanagon
 # move over the executables
 ADD https://github.com/puppetlabs/security-snyk-vanagon-action/releases/latest/download/vanagon_action /usr/local/bin/vanagon_action


### PR DESCRIPTION
This is a requirement for some of the vanagon dependencies.

See https://github.com/puppetlabs/bolt-vanagon/pull/200